### PR TITLE
Toggle disabled class on form group

### DIFF
--- a/app/assets/javascripts/effective_addresses/address_fields.js.coffee
+++ b/app/assets/javascripts/effective_addresses/address_fields.js.coffee
@@ -4,11 +4,14 @@ $(document).on 'change', "select[data-effective-address-country]", (event) ->
 
   url = "/addresses/subregions/#{country_code}"
   state_select = $(this).closest('form').find("select[data-effective-address-state='#{uuid}']").first()
+  state_select_label = $(this).closest('.disabled').first()
 
   if country_code.length == 0
     state_select.prop('disabled', true)
+    state_select_label.addClass('disabled')
     state_select.html('<option value="">please select a country</option>')
   else
     state_select.prop('disabled', false)
+    state_select_label.removeClass('disabled')
     state_select.find('option').first().text('loading...')
     state_select.load(url)


### PR DESCRIPTION
The toggles the disabled state for the Province / State label after a country is selected. See screenshot: http://cl.ly/image/3720033w1846/Image%202014-08-26%20at%2010.59.01%20AM.png

Note: using `closest(".disabled")` is probably not the best way to select this element. I'm using simple forms and bootstrap and the disabled class that needs to be toggled is on the `.form-group` div, otherwise we could select the for attribute of the label directly. Not sure what happens with formtastic.