### PR TITLE
Prefer String interpolation over concatenation

### DIFF
--- a/app/models/effective/address.rb
+++ b/app/models/effective/address.rb
@@ -126,7 +126,7 @@ module Effective
       output += "#{full_name}\n" if full_name.present?
       output += "#{address1}\n" if address1.present?
       output += "#{address2}\n" if address2.present?
-      output += [city.presence, state_code.presence, ' ' + postal_code.presence].compact.join(' ')
+      output += [city.presence, state_code.presence, " #{postal_code.presence}"].compact.join(' ')
       output += "\n"
       output += country.to_s
       output

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -48,4 +48,10 @@ describe Effective::Address do
     address.state.should eq 'New York'
   end
 
+  describe '#to_s' do
+    it 'works without a postal code' do
+      address.postal_code = nil
+      expect(address.to_s).to be_a(String)
+    end
+  end
 end


### PR DESCRIPTION
fixes #4

I considered removing the extra space before the postal code entirely.  Is there a good reason to include it there?