### PR TITLE
Converted simple_form to utilize i18n

### DIFF
--- a/app/views/effective/addresses/_address_fields_simple_form.html.haml
+++ b/app/views/effective/addresses/_address_fields_simple_form.html.haml
@@ -6,17 +6,18 @@
     - fa.object.errors.add(:address1, f.object.errors[method].first)
 
   - if use_full_name || fa.object.errors.include?(:full_name)
-    = fa.input :full_name, :required => required, :label => 'Full name', :placeholder => 'Full name'
+    = fa.input :full_name, :required => required
 
-  = fa.input :address1, :placeholder => 'Address', :label => 'Address 1', :required => required
-  = fa.input :address2, :label => 'Address 2'
-  = fa.input :city, :placeholder => 'City', :required => required
 
-  = fa.input :country_code, :as => :select, :label => 'Country', :prompt => 'Choose country...', :collection => region_options_for_simple_form_select(), :input_html => {'data-effective-address-country' => uuid}, :required => required
+  = fa.input :address1, :required => required
+  = fa.input :address2
+  = fa.input :city, :required => required
+
+  = fa.input :country_code, :as => :select, :collection => region_options_for_simple_form_select(), :input_html => {'data-effective-address-country' => uuid}, :required => required
 
   - if fa.object.try(:country_code).present?
-    = fa.input :state_code, :as => :select, :label => 'Province / State', :prompt => 'Please choose a country first', :collection => region_options_for_simple_form_select(Carmen::Country.coded(fa.object.country_code).subregions), :input_html => {'data-effective-address-state' => uuid}, :required => required
+    = fa.input :state_code, :as => :select, :collection => region_options_for_simple_form_select(Carmen::Country.coded(fa.object.country_code).subregions), :input_html => {'data-effective-address-state' => uuid}, :required => required
   - else
-    = fa.input :state_code, :as => :select, :label => 'Province / State', :disabled => true, :prompt => 'Please choose a country', :collection => [], :input_html => { 'data-effective-address-state' => uuid }, :required => required
+    = fa.input :state_code, :as => :select, :disabled => true, :collection => [], :input_html => { 'data-effective-address-state' => uuid }, :required => required
 
-  = fa.input :postal_code, :label => 'Postal / Zip code', :placeholder => 'Postal / Zip code', :required => required
+  = fa.input :postal_code, :required => required

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,25 @@
+en:
+  simple_form:
+    labels:
+      defaults:
+        full_name: Full name
+        address1: Address 1
+        address2: Address 2
+        country_code: Country
+        state_code: Province / State
+        postal_code: Postal / Zip code
+
+#    hints:
+#      defaults:
+
+    placeholders:
+      defaults:
+        full_name: Full name
+        address1: Address
+        city: City
+        postal_code: Postal / Zip code
+
+    prompts:
+      defaults:
+        country_code: Choose country...
+        state_code: Please choose a country first


### PR DESCRIPTION
Solves #8 

Surprisingly, simply converting it to i18n solved the problem I was seeing.

On load (with priority country):
![onload](https://cloud.githubusercontent.com/assets/136564/9234950/870d405c-4101-11e5-8f14-e14a923550b3.png)

De-select country:
![deselect-country](https://cloud.githubusercontent.com/assets/136564/9234960/8ebce262-4101-11e5-811b-7e9a08647021.png)

I don't think there is any change in behavior, labels, placeholders other than ridding us of the "Please choose country" even though one is already chosen.