### PR TITLE
Feature/ip-based preselection using optional geocoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/dummy/.sass-cache
+.ruby-*

--- a/README.md
+++ b/README.md
@@ -165,7 +165,13 @@ The actual permitted parameters are:
 
 ### Form Helpers
 
-Use the helper in a Formtastic or SimpleForm form to quickly create the address fields.  This example is in HAML:
+Use the helper in a Formtastic or SimpleForm form to quickly create the address fields. Currently only supports Formtastic and SimpleForm.
+                                                                                       
+When you select a country from the select input an AJAX GET request will be made to `effective_addresses.address_subregions_path` (`/addresses/subregions/:country_code`) 
+which populates the province/state dropdown with the selected country's states or provinces.
+
+
+#### Formtastic
 
 ```ruby
 = semantic_form_for @user do |f|
@@ -173,7 +179,11 @@ Use the helper in a Formtastic or SimpleForm form to quickly create the address 
   = effective_address_fields(f, :billing_address)
 
   = f.action :submit
+```
 
+#### SimpleForm
+
+```ruby
 = simple_form_for @user do |f|
   %h3 Billing Address
   = effective_address_fields(f, :billing_address)
@@ -181,9 +191,15 @@ Use the helper in a Formtastic or SimpleForm form to quickly create the address 
   = f.submit 'Save'
 ```
 
-Currently only supports Formtastic and SimpleForm.
+#### Field Ordering
+You may choose to order fields different than the default, such as putting the country first.  You can do so with the `:field_order` option, for example:
+```ruby
+= simple_form_for @user do |f|
+  %h3 Billing Address
+  = effective_address_fields(f, :billing_address, :field_order => [:country_code, :full_name, :address1, :address2, :city, :state_code, :postal_code])
 
-When you select a country from the select input an AJAX GET request will be made to `effective_addresses.address_subregions_path` (`/addresses/subregions/:country_code`) which populates the province/state dropdown with the selected country's states or provinces.
+  = f.submit 'Save'
+```
 
 ## Geocoder option
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,48 @@ Currently only supports Formtastic and SimpleForm.
 
 When you select a country from the select input an AJAX GET request will be made to `effective_addresses.address_subregions_path` (`/addresses/subregions/:country_code`) which populates the province/state dropdown with the selected country's states or provinces.
 
+## Geocoder option
+
+Effective addresses has an optional integration with [Geocoder](https://github.com/alexreisner/geocoder).  At it's simplest, this provides preselection and prefill of `country`, `state`, `city`, and `postal_code` based on the user's IP address. See [Geocoder](https://github.com/alexreisner/geocoder) for
+a complete list of possibilities.
+
+### Installation and Setup
+
+```ruby
+gem 'geocoder'
+```
+
+Add `config/initializer/geocoder.rb`, below is a sample:
+
+```ruby
+Geocoder.configure(
+    # geocoding options
+
+    # IP address geocoding service (see below for supported options):
+    #    https://github.com/alexreisner/geocoder#ip-address-services
+    ip_lookup: :telize,
+    cache: Rails.cache,
+    cache_prefix: 'geocoder:'
+)
+
+# Provide a hardcoded ip of 1.2.3.4 when in developmnt/test and the ip address resolves as localhost
+if %w(development test).include? Rails.env
+  module Geocoder
+    module Request
+      def geocoder_spoofable_ip_with_localhost_override
+        ip_candidate = geocoder_spoofable_ip_without_localhost_override
+        if ip_candidate == '127.0.0.1'
+          '1.2.3.4'
+        else
+          ip_candidate
+        end
+      end
+      alias_method_chain :geocoder_spoofable_ip, :localhost_override
+    end
+  end
+end
+```
+
 
 ## License
 

--- a/app/assets/javascripts/effective_addresses/address_fields.js.coffee
+++ b/app/assets/javascripts/effective_addresses/address_fields.js.coffee
@@ -1,9 +1,15 @@
 $(document).on 'change', "select[data-effective-address-country]", (event) ->
   country_code = $(this).val()
   uuid = $(this).data('effective-address-country')
+  form = $(this).closest('form')
 
+  # clear postal_code and city values on country change
+  form.find("input[data-effective-address-postal-code='#{uuid}']").val('')
+  form.find("input[data-effective-address-city='#{uuid}']").val('')
+
+  # load state options
   url = "/addresses/subregions/#{country_code}"
-  state_select = $(this).closest('form').find("select[data-effective-address-state='#{uuid}']").first()
+  state_select = form.find("select[data-effective-address-state='#{uuid}']").first()
 
   if country_code.length == 0
     state_select.prop('disabled', true).addClass('disabled').parent('.form-group').addClass('disabled')

--- a/app/helpers/effective_addresses_helper.rb
+++ b/app/helpers/effective_addresses_helper.rb
@@ -12,7 +12,7 @@ module EffectiveAddressesHelper
     address = form.object.send(method) || form.object.addresses.build(:category => method.to_s.gsub('_address', ''))
     effective_address_pre_select(address) if address.new_record?
 
-    opts = {:required => required, :use_full_name => use_full_name}.merge(options).merge({:f => form, :address => address, :method => method})
+    opts = {:required => required, :use_full_name => use_full_name, :field_order => [:full_name, :address1, :address2, :city, :country_code, :state_code, :postal_code]}.merge(options).merge({:f => form, :address => address, :method => method})
 
     if form.class.name == 'SimpleForm::FormBuilder'
       render :partial => 'effective/addresses/address_fields_simple_form', :locals => opts

--- a/app/helpers/effective_addresses_helper.rb
+++ b/app/helpers/effective_addresses_helper.rb
@@ -10,7 +10,7 @@ module EffectiveAddressesHelper
     use_full_name = form.object._validators[method.to_sym].any? { |v| v.kind_of?(EffectiveAddressFullNamePresenceValidator) }
 
     address = form.object.send(method) || form.object.addresses.build(:category => method.to_s.gsub('_address', ''))
-    address.country, address.state = *pre_selections if address.new_record?
+    effective_address_pre_select(address) if address.new_record?
 
     opts = {:required => required, :use_full_name => use_full_name}.merge(options).merge({:f => form, :address => address, :method => method})
 
@@ -23,16 +23,16 @@ module EffectiveAddressesHelper
     end
   end
 
-  def pre_selections
-    result = []
-
+  def effective_address_pre_select(address)
     if EffectiveAddresses.pre_selected_country.present?
-      result << EffectiveAddresses.pre_selected_country
-      result << EffectiveAddresses.pre_selected_state if (result[0].present? && EffectiveAddresses.pre_selected_state.present?)
+      address.country = EffectiveAddresses.pre_selected_country
+      address.state = EffectiveAddresses.pre_selected_state if (result[0].present? && EffectiveAddresses.pre_selected_state.present?)
     elsif @@use_geocoder
       data = request.location.data
-      result << data['country_code']
-      result << data['region_code']
+      address.country = data['country_code']
+      address.state = data['region_code']
+      address.postal_code = data['postal_code']
+      address.city = data['city']
     end
   end
 

--- a/app/helpers/effective_addresses_helper.rb
+++ b/app/helpers/effective_addresses_helper.rb
@@ -27,7 +27,7 @@ module EffectiveAddressesHelper
     if EffectiveAddresses.pre_selected_country.present?
       address.country = EffectiveAddresses.pre_selected_country
       address.state = EffectiveAddresses.pre_selected_state if (result[0].present? && EffectiveAddresses.pre_selected_state.present?)
-    elsif @@use_geocoder
+    elsif @@use_geocoder && request.location.present?
       data = request.location.data
       address.country = data['country_code']
       address.state = data['region_code']

--- a/app/views/effective/addresses/_address_fields_formtastic.html.haml
+++ b/app/views/effective/addresses/_address_fields_formtastic.html.haml
@@ -5,28 +5,41 @@
   - if ((f.object.errors.include?(method) && !f.object.errors.include?(:addresses)) rescue false)
     - fa.object.errors.add(:address1, f.object.errors[method].first)
 
-  - if use_full_name || fa.object.errors.include?(:full_name)
-    = fa.input :full_name, :required => true, :label => 'Full name', :placeholder => 'Full name'
+  - field_order.each do |field|
 
-  = fa.input :address1, :placeholder => 'Address', :label => "Address 1"
-  = fa.input :address2, :label => 'Address 2'
-  = fa.input :city, :placeholder => 'City'
-  = fa.input :country_code,
-    :as => :select,
-    :label => 'Country',
-    :prompt => 'Country...',
-    :collection => region_options_for_select(EffectiveAddresses.country_codes == :all ? Carmen::Country.all : Carmen::Country.all.select{ |c| EffectiveAddresses.country_codes.include?(c.code) rescue true}, fa.object.country_code, :priority => EffectiveAddresses.country_codes_priority),
-    :input_html => { 'data-effective-address-country' => uuid }
+    - case field
+      - when :full_name
+        - if use_full_name || fa.object.errors.include?(:full_name)
+          = fa.input :full_name, :required => true, :label => 'Full name', :placeholder => 'Full name'
 
-  - if fa.object.country_code.present?
-    = fa.input :state_code, :as => :select, :label => 'Province / State',
-      :collection => region_options_for_select(Carmen::Country.coded(fa.object.country_code).subregions, fa.object.state_code),
-      :prompt => 'please select a country',
-      :input_html => { 'data-effective-address-state' => uuid }
-  - else
-    = fa.input :state_code, :as => :select, :label => 'Province / State',
-      :collection => [],
-      :prompt => 'please select a country',
-      :input_html => {:disabled => 'disabled', 'data-effective-address-state' => uuid}
+      - when :address1
+        = fa.input :address1, :placeholder => 'Address', :label => "Address 1"
 
-  = fa.input :postal_code, :label => 'Postal / Zip code', :placeholder => 'Postal / Zip code'
+      - when :address2
+        = fa.input :address2, :label => 'Address 2'
+
+      - when :city
+        = fa.input :city, :placeholder => 'City'
+
+      - when :country_code
+        = fa.input :country_code,
+          :as => :select,
+          :label => 'Country',
+          :prompt => 'Country...',
+          :collection => region_options_for_select(EffectiveAddresses.country_codes == :all ? Carmen::Country.all : Carmen::Country.all.select{ |c| EffectiveAddresses.country_codes.include?(c.code) rescue true}, fa.object.country_code, :priority => EffectiveAddresses.country_codes_priority),
+          :input_html => { 'data-effective-address-country' => uuid }
+
+      - when :state_code
+        - if fa.object.country_code.present?
+          = fa.input :state_code, :as => :select, :label => 'Province / State',
+            :collection => region_options_for_select(Carmen::Country.coded(fa.object.country_code).subregions, fa.object.state_code),
+            :prompt => 'please select a country',
+            :input_html => { 'data-effective-address-state' => uuid }
+        - else
+          = fa.input :state_code, :as => :select, :label => 'Province / State',
+            :collection => [],
+            :prompt => 'please select a country',
+            :input_html => {:disabled => 'disabled', 'data-effective-address-state' => uuid}
+
+      - when :postal_code
+        = fa.input :postal_code, :label => 'Postal / Zip code', :placeholder => 'Postal / Zip code'

--- a/app/views/effective/addresses/_address_fields_simple_form.html.haml
+++ b/app/views/effective/addresses/_address_fields_simple_form.html.haml
@@ -11,7 +11,7 @@
 
   = fa.input :address1, :required => required
   = fa.input :address2
-  = fa.input :city, :required => required
+  = fa.input :city, :input_html => { 'data-effective-address-city' => uuid }, :required => required
 
   = fa.input :country_code, :as => :select, :collection => region_options_for_simple_form_select(), :input_html => {'data-effective-address-country' => uuid}, :required => required
 
@@ -20,4 +20,4 @@
   - else
     = fa.input :state_code, :as => :select, :disabled => true, :collection => [], :input_html => { 'data-effective-address-state' => uuid }, :required => required
 
-  = fa.input :postal_code, :required => required
+  = fa.input :postal_code, :input_html => { 'data-effective-address-postal-code' => uuid }, :required => required

--- a/app/views/effective/addresses/_address_fields_simple_form.html.haml
+++ b/app/views/effective/addresses/_address_fields_simple_form.html.haml
@@ -5,19 +5,30 @@
   - if ((f.object.errors.include?(method) && !f.object.errors.include?(:addresses)) rescue false)
     - fa.object.errors.add(:address1, f.object.errors[method].first)
 
-  - if use_full_name || fa.object.errors.include?(:full_name)
-    = fa.input :full_name, :required => required
+  - field_order.each do |field|
 
+    - case field
+      - when :full_name
+        - if use_full_name || fa.object.errors.include?(:full_name)
+          = fa.input :full_name, :required => required
 
-  = fa.input :address1, :required => required
-  = fa.input :address2
-  = fa.input :city, :input_html => { 'data-effective-address-city' => uuid }, :required => required
+      - when :address1
+        = fa.input :address1, :required => required
 
-  = fa.input :country_code, :as => :select, :collection => region_options_for_simple_form_select(), :input_html => {'data-effective-address-country' => uuid}, :required => required
+      - when :address2
+        = fa.input :address2
 
-  - if fa.object.try(:country_code).present?
-    = fa.input :state_code, :as => :select, :collection => region_options_for_simple_form_select(Carmen::Country.coded(fa.object.country_code).subregions), :input_html => {'data-effective-address-state' => uuid}, :required => required
-  - else
-    = fa.input :state_code, :as => :select, :disabled => true, :collection => [], :input_html => { 'data-effective-address-state' => uuid }, :required => required
+      - when :city
+        = fa.input :city, :input_html => { 'data-effective-address-city' => uuid }, :required => required
 
-  = fa.input :postal_code, :input_html => { 'data-effective-address-postal-code' => uuid }, :required => required
+      - when :country_code
+        = fa.input :country_code, :as => :select, :collection => region_options_for_simple_form_select(), :input_html => {'data-effective-address-country' => uuid}, :required => required
+
+      - when :state_code
+        - if fa.object.try(:country_code).present?
+          = fa.input :state_code, :as => :select, :collection => region_options_for_simple_form_select(Carmen::Country.coded(fa.object.country_code).subregions), :input_html => {'data-effective-address-state' => uuid}, :required => required
+        - else
+          = fa.input :state_code, :as => :select, :disabled => true, :collection => [], :input_html => { 'data-effective-address-state' => uuid }, :required => required
+
+      - when :postal_code
+        = fa.input :postal_code, :input_html => { 'data-effective-address-postal-code' => uuid }, :required => required

--- a/lib/generators/templates/effective_addresses.rb
+++ b/lib/generators/templates/effective_addresses.rb
@@ -13,13 +13,15 @@ EffectiveAddresses.setup do |config|
   # Select these countries ontop of the others
   config.country_codes_priority = ['US', 'CA'] # nil for no priority countries
 
-  # Preselect this country on any new address forms
-  # Valid values are: country code, country name, or nil
+  # Force this country to be preselected on any new address forms.
+  # Valid values are: country code, country name, or nil.
+  # Leave nil if using Geocoder for IP based discovery.
   config.pre_selected_country = nil
 
-  # Preselect this state on any new address forms
+  # Force this state to be preselected on any new address forms.
   # Must also define pre_selected_country for this to take affect
-  # Valid values are: state code, state name, or nil
+  # Valid values are: state code, state name, or nil.
+  # Leave nil if using Geocoder for IP based discovery.
   config.pre_selected_state = nil
 
   # Validate that the postal/zip code format is correct for these countries


### PR DESCRIPTION
This pull introduces Geocoder for IP-based preselection of city, state, country_code, postal_code.  It integrates some conveniences with the coffeescript to clear selection if country changes, as well as a new `:field_order` so that developers may choose to render fields in a different order.  In particular when using IP based detection, it makes more sense to verify country selection first, as four of the other selection are already prefilled based on it's value.

I've detailed the options in the readme, and I think this is a very nice addition.  There is no requirement to use Geocoder if one should choose not to, and I don't believe any of the changes have any backwards compatibility implications.

As far as I can tell this is good to release (as long as travis passes). 