### PR TITLE
Remove migrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/dummy/.sass-cache
+.ruby-*

--- a/app/models/effective/address.rb
+++ b/app/models/effective/address.rb
@@ -9,23 +9,7 @@ module Effective
 
     belongs_to :addressable, :polymorphic => true, :touch => true
 
-    structure do
-      category        :string, :validates => [:presence]
-
-      full_name       :string
-
-      address1        :string, :validates => [:presence]
-      address2        :string
-
-      city            :string, :validates => [:presence]
-
-      state_code      :string
-      country_code    :string, :validates => [:presence]
-
-      postal_code     :string, :validates => [:presence]
-
-      timestamps
-    end
+    validates_presence_of :category, :address1, :city, :country_code, :postal_code
 
     validates_presence_of :state_code, :if => Proc.new { |address| address.country_code.blank? || Carmen::Country.coded(address.country_code).try(:subregions).present? }
 

--- a/effective_addresses.gemspec
+++ b/effective_addresses.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "carmen-rails"
   s.add_dependency "coffee-rails"
   s.add_dependency "haml"
-  s.add_dependency "migrant"
 
   s.add_development_dependency "rspec-rails", '~> 3.0'
   s.add_development_dependency "factory_girl_rails"

--- a/lib/effective_addresses.rb
+++ b/lib/effective_addresses.rb
@@ -1,6 +1,5 @@
 require "effective_addresses/engine"
 require "effective_addresses/version"
-require 'migrant'     # Required for rspec to run properly
 
 module EffectiveAddresses
 

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,24 +1,24 @@
 class User < ActiveRecord::Base
-  structure do
-    # Devise attributes
-    encrypted_password      :string
-    reset_password_token    :string
-    reset_password_sent_at  :datetime
-    remember_created_at     :datetime
-    confirmation_sent_at    :datetime
-    confirmed_at            :datetime
-    confirmation_token      :string
-    unconfirmed_email       :string
-    sign_in_count           :integer, :default => 0
-    current_sign_in_at      :datetime
-    last_sign_in_at         :datetime
-    current_sign_in_ip      :string
-    last_sign_in_ip         :string
-
-    email                   :string
-    first_name              :string
-    last_name               :string
-
-    timestamps
-  end
+  # structure do
+  #   # Devise attributes
+  #   encrypted_password      :string
+  #   reset_password_token    :string
+  #   reset_password_sent_at  :datetime
+  #   remember_created_at     :datetime
+  #   confirmation_sent_at    :datetime
+  #   confirmed_at            :datetime
+  #   confirmation_token      :string
+  #   unconfirmed_email       :string
+  #   sign_in_count           :integer, :default => 0
+  #   current_sign_in_at      :datetime
+  #   last_sign_in_at         :datetime
+  #   current_sign_in_ip      :string
+  #   last_sign_in_ip         :string
+  #
+  #   email                   :string
+  #   first_name              :string
+  #   last_name               :string
+  #
+  #   timestamps
+  # end
 end


### PR DESCRIPTION
Remove migrant, caused problems when effective_addresses was included in applications that did not use migrant in models.  See #13 