### PR TITLE
Bug/geocoder result accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,17 @@ Add `config/initializer/geocoder.rb`, below is a sample:
 
 ```ruby
 Geocoder.configure(
-    # geocoding options
-
-    # IP address geocoding service (see below for supported options):
+    # Remote IP address geocoding service (see below for supported options):
     #    https://github.com/alexreisner/geocoder#ip-address-services
     ip_lookup: :telize,
+    
+    # Local IP address file database:
+    # 1. gem 'maxminddb'
+    # 2. download database: http://dev.maxmind.com/geoip/geoip2/geolite2/
+    # 3. save file in db/geocoder
+    # ip_lookup: :geoip2,
+    # geoip2: { file: File.expand_path('../../db/geocoder/GeoLite2-City.mmdb', File.dirname(__FILE__)) },
+    
     cache: Rails.cache,
     cache_prefix: 'geocoder:'
 )

--- a/app/helpers/effective_addresses_helper.rb
+++ b/app/helpers/effective_addresses_helper.rb
@@ -28,11 +28,11 @@ module EffectiveAddressesHelper
       address.country = EffectiveAddresses.pre_selected_country
       address.state = EffectiveAddresses.pre_selected_state if (result[0].present? && EffectiveAddresses.pre_selected_state.present?)
     elsif @@use_geocoder && request.location.present?
-      data = request.location.data
-      address.country = data['country_code']
-      address.state = data['region_code']
-      address.postal_code = data['postal_code']
-      address.city = data['city']
+      location = request.location
+      address.country = location.country_code
+      address.state = location.region_code
+      address.postal_code = location.postal_code
+      address.city = location.city
     end
   end
 

--- a/app/helpers/effective_addresses_helper.rb
+++ b/app/helpers/effective_addresses_helper.rb
@@ -30,7 +30,7 @@ module EffectiveAddressesHelper
     elsif @@use_geocoder && request.location.present?
       location = request.location
       address.country = location.country_code
-      address.state = location.region_code
+      address.state = location.state_code
       address.postal_code = location.postal_code
       address.city = location.city
     end


### PR DESCRIPTION
I found that I was using data hash values with geocoder, and those weren't guaranteed to be cross-provider compatible.  Switched to accessors, and added a sample config to the readme for a local IP database.